### PR TITLE
Revert "Update readme before publishing to crates.io"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ The following commands are available / planned:
 
 (*) For now, an alternative registry with Substrate SRML modules is available at https://dl.cloudsmith.io/public/steve-degosserie/substrate-mods/cargo/index.git
 
-## How to install
-
-```sh
-cargo install substrate-deps
-```
-
 ## Commands
 
 ### `substrate-deps add`
@@ -33,10 +27,12 @@ Add a new module dependency to your Substrate runtime's `Cargo.toml`.
 
 #### Examples
 
+Note: `substrate-deps` is not pubished to crates-io yet, so we're running from the sources with `cargo run`.
+
 To add an hypothetical `scml-template-module` that depends on the `srml-balances`module:
 ```sh
 $ # Add the module scml-template-module to the runtime whose manifest is specified as argument, using the specified alternative registry.
-$ substrate-deps add scml-template-module --manifest-path ../substrate-package/substrate-node-template/runtime/Cargo.toml --registry substrate-mods
+$ cargo run -- add scml-template-module --manifest-path ../substrate-package/substrate-node-template/runtime/Cargo.toml --registry substrate-mods
 
 Using registry 'substrate-mods' at: https://dl.cloudsmith.io/public/steve-degosserie/substrate-mods/cargo/index.git
     Updating 'https://dl.cloudsmith.io/public/steve-degosserie/substrate-mods/cargo/index.git' index
@@ -49,7 +45,7 @@ Added module scml-template-module v0.2.1 configuration in your node runtime.
 #### Usage
 
 ```plain
-$ substrate-deps add --help
+$ cargo run -- add --help
 USAGE:
     substrate-deps add [FLAGS] [OPTIONS] <module>
 
@@ -75,11 +71,13 @@ Generates a dependency graph of the modules used by your Substrate runtime.
 
 #### Examples
 
+Note: `substrate-deps` is not pubished to crates-io yet, so we're running from the sources with `cargo run`.
+
 This command output a dependency graph for [graphviz](https://graphviz.gitlab.io/download/), please make sure your have it install to be able to generate an image file with the instruction below.
 
 ```sh
 $ # Generate a dependency graph of the modules used by the runtime whose manifest is specified as argument and pipe it to the dot command to generate an image file.
-$ substrate-deps graph --manifest-path ../substrate-package/substrate-node-template/runtime/Cargo.toml | dot -Tpng > graph.png
+$ cargo run -- graph --manifest-path ../substrate-package/substrate-node-template/runtime/Cargo.toml | dot -Tpng > graph.png
 ```
 
 ### Substrate Runtime module metadata model


### PR DESCRIPTION
Reverts stiiifff/substrate-deps#8
Can't publish to crates.io just yet ... as we're depending on pending branches in cargo-edit & cargo-deps.